### PR TITLE
fix(build/wrap.go): make it work on Apple Silicon

### DIFF
--- a/build/wrap.go
+++ b/build/wrap.go
@@ -1,3 +1,4 @@
+//go:build none
 // +build none
 
 package main
@@ -734,7 +735,16 @@ func wrapTor(tgt string, lock *lockJson) (string, string, error) {
 	if err := autogen.Run(); err != nil {
 		return "", "", err
 	}
-	configure := exec.Command("./configure", "--disable-asciidoc")
+	configureArgs := []string{
+		"--disable-asciidoc",
+	}
+	// If you're using M1 or later CPUs, homebrew installs under /opt/local as
+	// opposed to /usr/local. We need to tell tor's configure about that.
+	if info, err := os.Stat("/opt/homebrew"); err == nil && info.IsDir() {
+		configureArgs = append(configureArgs, "--with-libevent-dir=/opt/homebrew/")
+		configureArgs = append(configureArgs, "--with-openssl-dir=/opt/homebrew/opt/openssl@1.1/")
+	}
+	configure := exec.Command("./configure", configureArgs...)
 	configure.Dir = tgtf
 	configure.Stdout = os.Stdout
 	configure.Stderr = os.Stderr

--- a/build/wrap.go
+++ b/build/wrap.go
@@ -708,7 +708,7 @@ func wrapTor(tgt string, lock *lockJson) (string, string, error) {
 	if lock != nil {
 		checkout = lock.Tor
 	} else {
-		checkout = "release-0.4.6"
+		checkout = "maint-0.4.7"
 	}
 	checkouter := exec.Command("git", "checkout", checkout)
 	checkouter.Dir = tgtf

--- a/build/wrap.go
+++ b/build/wrap.go
@@ -122,15 +122,16 @@ func main() {
 			"torHash":      torHash,
 		})
 		ioutil.WriteFile("README.md", buf.Bytes(), 0644)
-		buff, err := json.Marshal(lockJson{
+		buff, err := json.MarshalIndent(lockJson{
 			Zlib:     zlibHash,
 			Libevent: libeventHash,
 			Openssl:  opensslHash,
 			Tor:      torHash,
-		})
+		}, "", "  ")
 		if err != nil {
 			panic(err)
 		}
+		buff = append(buff, '\n')
 		ioutil.WriteFile("lock.json", buff, 0644)
 	}
 }


### PR DESCRIPTION
On Apple Silicon systems, Homebrew installs under /opt. We need to tell tor's configure about that.

While there, make the lockfile more pleasant to use.

While there, make sure we follow the main-0.4.7 branch of tor.

This work is under the https://github.com/ooni/probe/issues/2365 umbrella. While I managed to get rid of go-libtor for Android, doing the same for iOS seems a bit cumbersome, and I already spent lots of time on this task. Therefore, I am going to update go-libtor such that we can use it on iOS systems. This diff implements the first part of this N-th side task, that is, making sure I am a bit more comfortable using this library and I can update it confidently.